### PR TITLE
export mesh buffer as obj

### DIFF
--- a/qrenderdoc/Windows/BufferViewer.h
+++ b/qrenderdoc/Windows/BufferViewer.h
@@ -50,6 +50,7 @@ struct BufferExport
   enum ExportFormat
   {
     CSV,
+    OBJ,
     RawBytes,
   };
 
@@ -211,6 +212,7 @@ private:
   QMenu *m_ExportMenu = NULL;
 
   QAction *m_ExportCSV = NULL;
+  QAction *m_ExportOBJ = NULL;
   QAction *m_ExportBytes = NULL;
   QAction *m_DebugVert = NULL;
 

--- a/qrenderdoc/Windows/BufferViewer.ui
+++ b/qrenderdoc/Windows/BufferViewer.ui
@@ -778,7 +778,7 @@
        <bool>true</bool>
       </property>
       <property name="toolTip">
-       <string>Export to CSV or raw bytes</string>
+       <string>Export to CSV or OBJ or raw bytes</string>
       </property>
       <property name="icon">
        <iconset resource="../Resources/resources.qrc">


### PR DESCRIPTION
Export mesh as .obj in buffer view (extending existing csv/bin methods)
image

Some details which may be improved, any suggestion?

For now there are some hard coded attributes-name mapping. I'm not aware if any elegent way to detect or should we provide a configuration dialog (like position-v, normal-vn, etc.)?
Face index in triangle is force flipped. Should we have setting for this?
I'll support fbx later when I'm free.